### PR TITLE
A few edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Behaviors :
 * max : max value || default=100.
 * stopper : stop at 0 & 100 on keydown/mousewheel || default=true.
 * readOnly : disable input and events.
+* flatMouse : the dial responds to up-down mouse movement instead of radial mouse movement.
 
 UI :
 * cursor : display mode "cursor" | default=gauge.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Behaviors :
 * stopper : stop at 0 & 100 on keydown/mousewheel || default=true.
 * readOnly : disable input and events.
 * flatMouse : the dial responds to up-down mouse movement instead of radial mouse movement.
+* noScroll : disable the mouse wheel for the dial.
 
 UI :
 * cursor : display mode "cursor" | default=gauge.

--- a/js/jquery.kontrol.js
+++ b/js/jquery.kontrol.js
@@ -90,6 +90,7 @@ $(function () {
                     max : this.$.data('max') || 100,
                     stopper : true,
                     readOnly : this.$.data('readonly'),
+                    noScroll : this.$.data('noScroll'),
 
                     // UI
                     cursor : (this.$.data('cursor') === true && 30)
@@ -474,6 +475,9 @@ $(function () {
             // bind MouseWheel
             var s = this,
                 mw = function (e) {
+                            if(s.o.noScroll) 
+                                return;
+
                             e.preventDefault();
                             
                             var ori = e.originalEvent

--- a/js/jquery.kontrol.js
+++ b/js/jquery.kontrol.js
@@ -54,6 +54,8 @@ $(function () {
         this.cv = null; // change value ; not commited value
         this.x = 0; // canvas x position
         this.y = 0; // canvas y position
+        this.mx = 0; // x value of mouse down point of the current mouse move
+        this.my = 0; // y value of mouse down point of the current mose move
         this.$c = null; // jQuery canvas element
         this.c = null; // rendered canvas context
         this.t = 0; // touches index
@@ -211,7 +213,8 @@ $(function () {
                 
                 var v = s.xy2val(
                             e.originalEvent.touches[s.t].pageX,
-                            e.originalEvent.touches[s.t].pageY
+                            e.originalEvent.touches[s.t].pageY,
+                            'touch'
                             );
 
                 if (v == s.cv) return;
@@ -260,7 +263,7 @@ $(function () {
         this._mouse = function (e) {
 
             var mouseMove = function (e) {
-                var v = s.xy2val(e.pageX, e.pageY);
+                var v = s.xy2val(e.pageX, e.pageY, 'mouse');
                 if (v == s.cv) return;
 
                 if (
@@ -278,8 +281,10 @@ $(function () {
             ) return;
             
             // First click
+            s.mx = e.pageX;
+            s.my = e.pageY;
             mouseMove(e);
-            
+
             // Mouse events listeners
             k.c.d
                 .bind("mousemove.k", mouseMove)
@@ -378,7 +383,7 @@ $(function () {
         this.init = function () {}; // each time configure triggered
         this.change = function (v) {}; // on change
         this.val = function (v) {}; // on release
-        this.xy2val = function (x, y) {}; //
+        this.xy2val = function (x, y, method) {}; //
         this.draw = function () {}; // on change / on release
         this.clear = function () { this._clear(); };
 
@@ -418,6 +423,7 @@ $(function () {
                     bgColor : this.$.data('bgcolor') || '#EEEEEE',
                     angleOffset : this.$.data('angleoffset') || 0,
                     angleArc : this.$.data('anglearc') || 360,
+                    flatMouse : this.$.data('flatMouse'),
                     inline : true
                 }, this.o
             );
@@ -434,23 +440,29 @@ $(function () {
             }
         };
 
-        this.xy2val = function (x, y) {
+        this.xy2val = function (x, y, m) {
             var a, ret;
 
-            a = Math.atan2(
-                        x - (this.x + this.w2)
-                        , - (y - this.y - this.w2)
-                    ) - this.angleOffset;
+            if ((m === 'mouse') && (this.o.flatMouse)) {
+                a = ((this.my - y) + (x - this.mx)) / (this.o.height);
+                ret = ~~ (a * (this.o.max - this.o.min) + parseFloat(this.v));
+                ret = max(min(ret, this.o.max), this.o.min);
+            } else {
+                a = Math.atan2(
+                    x - (this.x + this.w2)
+                    , - (y - this.y - this.w2)
+                ) - this.angleOffset;
 
-            if(this.angleArc != this.PI2 && (a < 0) && (a > -0.5)) {
-                // if isset angleArc option, set to min if .5 under min
-                a = 0;
-            } else if (a < 0) {
-                a += this.PI2;
-            }
+                if(this.angleArc != this.PI2 && (a < 0) && (a > -0.5)) {
+                    // if isset angleArc option, set to min if .5 under min
+                    a = 0;
+                } else if (a < 0) {
+                    a += this.PI2;
+                }
 
-            ret = ~~ (0.5 + (a * (this.o.max - this.o.min) / this.angleArc))
+                ret = ~~ (0.5 + (a * (this.o.max - this.o.min) / this.angleArc))
                     + this.o.min;
+            }
 
             this.o.stopper
             && (ret = max(min(ret, this.o.max), this.o.min));

--- a/js/jquery.kontrol.js
+++ b/js/jquery.kontrol.js
@@ -708,6 +708,7 @@ $(function () {
         this._coord = function() {
             for(var i in this.v) {
                 this.m[i] = ~~ (0.5 + ((this.s[i] * this.v[i] - this.o.min) / this.f[i]) + this.cur2) ;
+                this.p[i] = this.m[i];
             }
         };
 
@@ -752,6 +753,7 @@ $(function () {
         this.xy2val = function (x, y) {
             this.m[0] = max(this.cur2, min(x - this.x, this.o.width - this.cur2));
             this.m[1] = max(this.cur2, min(y - this.y, this.o.height - this.cur2));
+
             return {
                 0 : ~~ (this.o.min + (this.m[0] - this.cur2) * this.f[0]),
                 1 : ~~ (this.o.min + (this.o.height - this.m[1] - this.cur2) * this.f[1])
@@ -801,6 +803,7 @@ $(function () {
 
             c.beginPath();
             c.lineWidth = this.cursor;
+            console.log(this.m);
             c.strokeStyle = r  ? this.o.fgColor : this.fgColor;
             c.moveTo(this.m[0], this.m[1] + this.cur2);
             c.lineTo(this.m[0], this.m[1] - this.cur2);

--- a/js/jquery.kontrol.js
+++ b/js/jquery.kontrol.js
@@ -803,7 +803,6 @@ $(function () {
 
             c.beginPath();
             c.lineWidth = this.cursor;
-            console.log(this.m);
             c.strokeStyle = r  ? this.o.fgColor : this.fgColor;
             c.moveTo(this.m[0], this.m[1] + this.cur2);
             c.lineTo(this.m[0], this.m[1] - this.cur2);


### PR DESCRIPTION
Hey! Great work on this project!  I've made a few changes that I found useful.  It'd be great if you could integrate these into the main repo
- Fixed a bug with the XY pad - it wouldn't show the previous parameter and canceling and operation with the escape key didn't work properly.
- Added a "no scroll" option. On dense UIs, sometimes you don't want the mouse wheel to edit parameters.  Now there's an option for that.
- Added a "flat mouse" control option.  Professional audio editing software like DAWs and plug-ins have been using on-screen mouse-based knobs for approximately 30 years.  The standard that has developed in that time is that the knobs are controlled _linearly_ by the mouse, even though they display radially.  I know that this is slightly less immediately intuitive, and it doesn't make any sense for touch control.  However, there are a large number of users of professional audio applications that will be incredibly annoyed by the radial mouse control that is currently the only option on your knobs.  I've added an option to provide the more traditional mouse-based behavior.  The flag does not affect touch control.
